### PR TITLE
CLS compliance

### DIFF
--- a/Rebus.AmazonSQS.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.AmazonSQS.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
+
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4c1ecbec-5a81-4b07-857e-6b511c4c92b1")]

--- a/Rebus.AmazonSQS/Properties/AssemblyInfo.cs
+++ b/Rebus.AmazonSQS/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("586dc77b-804e-4b66-8a2f-33ce49362a27")]

--- a/Rebus.Async.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Async.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("029a88c4-9350-497e-8ee8-b6965c7d7a90")]

--- a/Rebus.Async/Properties/AssemblyInfo.cs
+++ b/Rebus.Async/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("206bfbfd-dd80-4bac-a50a-caee097da9ad")]

--- a/Rebus.Autofac.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Autofac.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("07f104a3-26b6-41fe-934c-7bd8404bea86")]

--- a/Rebus.Autofac/Properties/AssemblyInfo.cs
+++ b/Rebus.Autofac/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5d16f679-0329-4643-8db5-6b523c5a8f7e")]

--- a/Rebus.AzureServiceBus.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.AzureServiceBus.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("487099fd-a3df-4f0b-ba50-7ee9ecf4fd10")]

--- a/Rebus.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Rebus.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d01643a8-22fc-45f4-9cb3-51a8c2d8bcc3")]

--- a/Rebus.AzureStorage.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.AzureStorage.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("40e50996-09b5-43e0-b8dd-dc9b62747128")]

--- a/Rebus.AzureStorage/Properties/AssemblyInfo.cs
+++ b/Rebus.AzureStorage/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ddbf60ee-1293-4bab-bca6-e6b3cfb13c67")]

--- a/Rebus.CastleWindsor.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.CastleWindsor.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("62d02ea7-77c0-465d-8b1e-9bfd780ca5d9")]

--- a/Rebus.CastleWindsor/Properties/AssemblyInfo.cs
+++ b/Rebus.CastleWindsor/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("21bd1372-5a58-4970-9552-b72e07830ec7")]

--- a/Rebus.DryIoc.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.DryIoc.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ef482365-2098-4f7a-ad5e-9f55a8f7457e")]

--- a/Rebus.DryIoc/Properties/AssemblyInfo.cs
+++ b/Rebus.DryIoc/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8547b969-4b81-481d-8c16-45ce3e4a072e")]

--- a/Rebus.Forklift.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Rebus.Forklift.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8843aeea-43a8-4aa4-81d5-8527dcb9ac43")]

--- a/Rebus.Forklift.AzureStorageQueues/Properties/AssemblyInfo.cs
+++ b/Rebus.Forklift.AzureStorageQueues/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d4807299-043b-4522-a5ed-d4018057c7e9")]

--- a/Rebus.Forklift.Common/Properties/AssemblyInfo.cs
+++ b/Rebus.Forklift.Common/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a57f61a4-0b17-4a31-83b6-dfdf085c02f2")]

--- a/Rebus.Forklift.Msmq/Properties/AssemblyInfo.cs
+++ b/Rebus.Forklift.Msmq/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9fe49a00-10f7-412a-8ad3-4ffb0b87480f")]

--- a/Rebus.Forklift.RabbitMq/Properties/AssemblyInfo.cs
+++ b/Rebus.Forklift.RabbitMq/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9781c814-18e2-412a-a504-f5572424e0dd")]

--- a/Rebus.Jil.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Jil.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f29343ef-08dc-481a-b8e4-e28a1d2c03e8")]

--- a/Rebus.Jil/Properties/AssemblyInfo.cs
+++ b/Rebus.Jil/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a0fa1ee4-f5a0-4cc7-9ea3-ea2314fe3465")]

--- a/Rebus.LightInject.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.LightInject.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ef482365-2098-4f7a-ad5e-9f55a8f7457e")]

--- a/Rebus.LightInject/Properties/AssemblyInfo.cs
+++ b/Rebus.LightInject/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8547b969-4b81-481d-8c16-45ce3e4a072e")]

--- a/Rebus.Log4net/Properties/AssemblyInfo.cs
+++ b/Rebus.Log4net/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9a91b5f3-8246-4795-9bc2-4c79bf15bab6")]

--- a/Rebus.MongoDb.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.MongoDb.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f7773b8a-5f2d-405e-8c89-afe0246e7418")]

--- a/Rebus.MongoDb/Properties/AssemblyInfo.cs
+++ b/Rebus.MongoDb/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7f0acdef-24a2-496f-b9e1-87a80807fbbf")]

--- a/Rebus.MsgPack.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.MsgPack.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("adc481aa-3042-41ba-b182-eb11cd085926")]

--- a/Rebus.MsgPack/Properties/AssemblyInfo.cs
+++ b/Rebus.MsgPack/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b7fff4b4-efe2-44f9-b7ab-19b206fb6b90")]

--- a/Rebus.NLog.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.NLog.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("280c1e09-9e36-4213-bb1e-d4c75b6d74ba")]

--- a/Rebus.NLog/Properties/AssemblyInfo.cs
+++ b/Rebus.NLog/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ab9522f6-8115-407a-8752-3777a5bbfc14")]

--- a/Rebus.NewtonsoftJson/Properties/AssemblyInfo.cs
+++ b/Rebus.NewtonsoftJson/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2e5dbe80-dd16-496b-a2b1-baee3edf9c30")]

--- a/Rebus.Ninject.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Ninject.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("11aed8bb-7c92-406b-bf19-145d36ecff20")]

--- a/Rebus.Ninject/Properties/AssemblyInfo.cs
+++ b/Rebus.Ninject/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("85fd2cb2-4fb2-4493-a710-74e7b9546b6e")]

--- a/Rebus.Owin.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Owin.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("86b582b4-d020-46b1-ba99-81891b55c522")]

--- a/Rebus.Owin/Properties/AssemblyInfo.cs
+++ b/Rebus.Owin/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("244db76b-41d9-4f4f-9f09-fdf8b3fb35d0")]

--- a/Rebus.PostgreSql.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.PostgreSql.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fc962a72-cd38-4c69-ba35-a55b081571fd")]

--- a/Rebus.PostgreSql/Properties/AssemblyInfo.cs
+++ b/Rebus.PostgreSql/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -13,10 +14,11 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
+// Setting ComVisible to false makes the types in this assembly not visible ghtInjectContainerAdapter
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d084a01a-9f31-4ff2-9113-2d50b9f5413d")]

--- a/Rebus.Protobuf.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Protobuf.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ce94e30a-6a5a-4bf8-910c-b6302911a4b3")]

--- a/Rebus.Protobuf/Properties/AssemblyInfo.cs
+++ b/Rebus.Protobuf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e18557d6-04ad-4c68-a69d-4ee8d614e437")]

--- a/Rebus.RabbitMq.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.RabbitMq.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("72d62473-5fe6-4628-a7b3-70ec3a6d3ad7")]

--- a/Rebus.RabbitMq/Properties/AssemblyInfo.cs
+++ b/Rebus.RabbitMq/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e7f3f56a-c56e-4096-a3d8-51c250169a1a")]

--- a/Rebus.RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMqTransport.cs
@@ -51,13 +51,14 @@ namespace Rebus.RabbitMq
         /// <summary>
         /// Constructs the transport with a connection to the RabbitMQ instance specified by the given connection string
         /// </summary>
-        public RabbitMqTransport(string connectionString, string inputQueueAddress, IRebusLoggerFactory rebusLoggerFactory, ushort maxMessagesToPrefetch = 50)
+        public RabbitMqTransport(string connectionString, string inputQueueAddress, IRebusLoggerFactory rebusLoggerFactory, int maxMessagesToPrefetch = 50)
         {
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
+						if (maxMessagesToPrefetch <= 0) throw new ArgumentException($"Cannot set 'maxMessagesToPrefetch' to {maxMessagesToPrefetch} - it must be at least 1!");
 
-            _connectionManager = new ConnectionManager(connectionString, inputQueueAddress, rebusLoggerFactory);
-            _maxMessagesToPrefetch = maxMessagesToPrefetch;
+						_connectionManager = new ConnectionManager(connectionString, inputQueueAddress, rebusLoggerFactory);
+            _maxMessagesToPrefetch = (ushort)maxMessagesToPrefetch;
             _log = rebusLoggerFactory.GetCurrentClassLogger();
             Address = inputQueueAddress;
         }

--- a/Rebus.RavenDb.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.RavenDb.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("f2e007c9-9d33-4a64-8d22-cf2fa10ff787")]

--- a/Rebus.RavenDb/Properties/AssemblyInfo.cs
+++ b/Rebus.RavenDb/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("07f65f4e-a37d-4693-b7c2-0ecc46b25c19")]

--- a/Rebus.Recipes.Test/Properties/AssemblyInfo.cs
+++ b/Rebus.Recipes.Test/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("318c14db-471a-428d-894e-e0cebfcc03b8")]

--- a/Rebus.Recipes/Properties/AssemblyInfo.cs
+++ b/Rebus.Recipes/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e268d0ba-ebcb-45f4-948b-488c68d1a228")]

--- a/Rebus.Serilog/Properties/AssemblyInfo.cs
+++ b/Rebus.Serilog/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b7476695-c7a9-4c10-8da4-ba6a92c52c26")]

--- a/Rebus.SimpleInjector.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.SimpleInjector.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("15c0d869-d45f-43e3-8a27-52e05a5829e5")]

--- a/Rebus.SimpleInjector/Properties/AssemblyInfo.cs
+++ b/Rebus.SimpleInjector/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("34a7aa21-c36f-4908-b6be-ebaf09e28d7d")]

--- a/Rebus.StructureMap.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.StructureMap.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("34446594-3678-49ac-a8b0-3575977348ff")]

--- a/Rebus.StructureMap/Properties/AssemblyInfo.cs
+++ b/Rebus.StructureMap/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d55faf57-490e-4b7d-8f91-b1214e2d074c")]

--- a/Rebus.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a6b179b4-98ae-44a6-b047-f7042416c824")]

--- a/Rebus.TransactionScopes.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.TransactionScopes.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6eeb0bce-70dd-4c20-9ea6-5303c4284736")]

--- a/Rebus.TransactionScopes/Properties/AssemblyInfo.cs
+++ b/Rebus.TransactionScopes/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("63fde9a0-6880-4a72-bde0-78b1e019bdcd")]

--- a/Rebus.UnitOfWork.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.UnitOfWork.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a3ede74e-e9e2-431c-830c-3ffe7ef5b1ff")]

--- a/Rebus.UnitOfWork/Properties/AssemblyInfo.cs
+++ b/Rebus.UnitOfWork/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e77b5611-da49-4977-bd69-c413a5d4221b")]

--- a/Rebus.Unity.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Unity.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5527e4f3-11d2-424d-b880-ddfa6ef058de")]

--- a/Rebus.Unity/Properties/AssemblyInfo.cs
+++ b/Rebus.Unity/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("54b2608c-d52a-4806-87f7-0e6ed229083d")]

--- a/Rebus.Wire.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.Wire.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("020f1df4-9eba-4463-98bc-828f2017af0a")]

--- a/Rebus.Wire/Properties/AssemblyInfo.cs
+++ b/Rebus.Wire/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("83d74da3-f80d-4ad8-a6d7-847a76527cbb")]

--- a/Rebus.XmlConfig.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.XmlConfig.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("03567465-443d-42a7-bba2-04d1a8496e79")]

--- a/Rebus.XmlConfig/Properties/AssemblyInfo.cs
+++ b/Rebus.XmlConfig/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -17,6 +18,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("bc1468c6-0326-47af-aae4-a2000f5c87a0")]

--- a/Rebus/Properties/AssemblyInfo.cs
+++ b/Rebus/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d384c2fc-06fb-4e20-a3a3-2be123e1cd88")]


### PR DESCRIPTION
Added CLSCompliant attributes to fix #513

Projects that are now compliant:
Rebus
Rebus.RabbitMq
Rebus.MongoDb
Rebus.AzureServiceBus
Rebus.CastleWindsor
Rebus.Serilog
Rebus.NLog
Rebus.Log4net
Rebus.AmazonSQS
Rebus.Unity
Rebus.Ninject
Rebus.Autofac
Rebus.NewtonsoftJson
Rebus.SimpleInjector
Rebus.XmlConfig
Rebus.StructureMap
Rebus.Forklift.Msmq
Rebus.Forklift.Common
Rebus.Forklift.RabbitMq
Rebus.Forklift.AzureServiceBus
Rebus.Forklift.AzureStorageQueues
Rebus.TransactionScopes
Rebus.Async
Rebus.UnitOfWork
Rebus.Wire
Rebus.Owin
Rebus.Recipes
Rebus.Recipes.Test
Rebus.MsgPack